### PR TITLE
Update actions workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build docker
-        run: docker-compose build app
+        run: docker compose build app
       - name: Update CIDRs
-        run: docker-compose run --rm app
+        run: docker compose run --rm app
       - name: Push updates
         run: |
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
- run on Ubuntu 24.04 instead of 20.04
- use docker compose plugin instead of docker-compose, which is no longer available
- update actions/checkout to v4, v2 is using a deprecated version of node